### PR TITLE
Fix lint heading

### DIFF
--- a/deepchat/README.md
+++ b/deepchat/README.md
@@ -72,9 +72,8 @@ npm run dev
 - **Run frontend tests**: `npm test -- --filter=frontend`
 - **Run backend tests**: `npm test -- --filter=backend`
 
-##  linting and Formatting
+## Linting and Formatting
 
 - **Lint all packages**: `npm run lint`
 - **Format all files**: `npm run format`
-
 Linting and formatting are also configured to run automatically on pre-commit. 


### PR DESCRIPTION
## Summary
- fix heading case for Linting section in deepchat README

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dcc58c44083258027f80a90d60939