### PR TITLE
Use mongodb-memory-server for backend tests

### DIFF
--- a/deepchat/apps/backend/package.json
+++ b/deepchat/apps/backend/package.json
@@ -35,6 +35,7 @@
     "@types/uuid": "^9.0.8",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
+    "mongodb-memory-server": "^8.12.2",
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.2",
     "ts-node-dev": "^2.0.0",

--- a/deepchat/apps/backend/tests/health.test.ts
+++ b/deepchat/apps/backend/tests/health.test.ts
@@ -1,12 +1,28 @@
 import supertest from 'supertest';
-import app from '@backend/server';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
 
-const request = supertest(app);
+let request: supertest.SuperTest<supertest.Test>;
+let mongoServer: MongoMemoryServer;
+let app: any;
 
 describe('GET /api/health', () => {
+    beforeAll(async () => {
+        mongoServer = await MongoMemoryServer.create();
+        process.env.MONGO_URI = mongoServer.getUri();
+        const mod = await import('@backend/server');
+        app = mod.default;
+        request = supertest(app);
+    });
+
+    afterAll(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+    });
+
     it('should return 200 OK', async () => {
         const res = await request.get('/api/health');
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ status: 'ok' });
     });
-}); 
+});


### PR DESCRIPTION
## Summary
- add `mongodb-memory-server` dev dependency
- spin up in-memory MongoDB for backend auth and health tests

## Testing
- `npm test -w apps/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f14594b448325babfd4344bc0f36e