### PR TITLE
Use logger in server startup

### DIFF
--- a/deepchat/apps/backend/src/server.ts
+++ b/deepchat/apps/backend/src/server.ts
@@ -6,6 +6,7 @@ import cookieParser from 'cookie-parser';
 import mainRouter from '@backend/routes';
 import { connectDB } from '@backend/config/database';
 import { initWhatsApp } from '@backend/services/whatsappService';
+import { logger as appLogger } from 'utils';
 
 dotenv.config();
 
@@ -45,7 +46,7 @@ io.on('connection', (socket) => {
 });
 
 server.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}`);
+    appLogger.info(`Server is running on port ${PORT}`);
 });
 
 export default app; 


### PR DESCRIPTION
## Summary
- log server start with the shared logger
- add missing logger import

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686f1b927a108325a9db6c7c22dfa072