### PR TITLE
Enforce JWT secret in backend

### DIFF
--- a/deepchat/apps/backend/src/config/index.ts
+++ b/deepchat/apps/backend/src/config/index.ts
@@ -2,10 +2,14 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+if (!process.env.JWT_SECRET) {
+    throw new Error('JWT_SECRET is not defined in the environment variables.');
+}
+
 export const config = {
     port: process.env.PORT || 5000,
     mongoUri: process.env.MONGO_URI,
     openaiApiKey: process.env.OPENAI_API_KEY,
-    jwtSecret: process.env.JWT_SECRET || 'a-super-secret-key',
+    jwtSecret: process.env.JWT_SECRET,
     jwtExpiresIn: process.env.JWT_EXPIRES_IN || '1d',
-}; 
+};

--- a/deepchat/apps/backend/tests/auth.test.ts
+++ b/deepchat/apps/backend/tests/auth.test.ts
@@ -1,5 +1,6 @@
 import supertest from 'supertest';
-import app from '@backend/server';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+const app = require('@backend/server').default;
 import mongoose from 'mongoose';
 import User from '@backend/models/User';
 

--- a/deepchat/apps/backend/tests/health.test.ts
+++ b/deepchat/apps/backend/tests/health.test.ts
@@ -1,5 +1,6 @@
 import supertest from 'supertest';
-import app from '@backend/server';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+const app = require('@backend/server').default;
 
 const request = supertest(app);
 

--- a/deepchat/infrastructure/docker-compose.yml
+++ b/deepchat/infrastructure/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - MONGO_URI=mongodb://mongo:27017/deepchat
       - OPENAI_API_KEY=${OPENAI_API_KEY} # Should be in a .env file
+      - JWT_SECRET=development-secret
     depends_on:
       - mongo
 


### PR DESCRIPTION
## Summary
- require `JWT_SECRET` in backend config and throw during startup if missing
- provide `JWT_SECRET` when running locally via docker-compose
- ensure backend tests set `JWT_SECRET` before importing the server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1b8f75748325976bdb5e0900916a